### PR TITLE
Fix: Streamline Travis configuration across repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ install:
   - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi
 
 before_script:
-  - mkdir -p "$HOME/.php-cs-fixer"
-  - mkdir -p build/logs
+  - mkdir -p $HOME/.php-cs-fixer
 
 script:
   - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs --diff --dry-run --verbose; fi


### PR DESCRIPTION
This PR

* [x] streamlines the Travis CI configuration across repositories
